### PR TITLE
Hotfix/sentry current user availability

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,8 +19,7 @@ class ApiController < ActionController::API
 
   # todo(juneja) check if this sentry code can be moved to a concern
   def set_raven_context!
-    return if @current_user.blank?
-    Raven.user_context(id: @current_user.id)
+    @current_user.blank? ? Raven.user_context(id: nil) : Raven.user_context(id: @current_user.id)
     Raven.extra_context(generate_sentry_params)
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,6 +19,7 @@ class ApiController < ActionController::API
 
   # todo(juneja) check if this sentry code can be moved to a concern
   def set_raven_context!
+    return if @current_user.blank?
     Raven.user_context(id: @current_user.id)
     Raven.extra_context(generate_sentry_params)
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,6 +19,7 @@ class ApiController < ActionController::API
 
   # todo(juneja) check if this sentry code can be moved to a concern
   def set_raven_context!
+    # set Raven context irrespective of the user presence for in depth error analysis
     @current_user.blank? ? Raven.user_context(id: nil) : Raven.user_context(id: @current_user.id)
     Raven.extra_context(generate_sentry_params)
   end

--- a/app/lib/exception_handler.rb
+++ b/app/lib/exception_handler.rb
@@ -30,22 +30,18 @@ module ExceptionHandler extend ActiveSupport::Concern
   end
 
   def record_not_found(e)
-    alert_sentry(e)
     json_response( { message: Message.not_found }, :not_found)
   end
 
   def four_twenty_two(e)
-    alert_sentry(e)
     json_response({ message: e.message }, :unprocessable_entity)
   end
 
   def four_zero_zero(e)
-    alert_sentry(e)
     json_response({ message: e.message }, :bad_request)
   end
 
   def unauthorized_request(e)
-    alert_sentry(e)
     json_response({ message: e.message }, :unauthorized)
   end
 

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -10,6 +10,6 @@ class JsonWebToken
     body = JWT.decode(token, HMAC_SECRET).first
     HashWithIndifferentAccess.new body
   rescue JWT::DecodeError => e
-    raise ExceptionHandler::InvalidToken, e.message
+    raise ExceptionHandler::InvalidToken, Message.invalid_token
   end
 end

--- a/app/services/auth_services/authorize_api_request.rb
+++ b/app/services/auth_services/authorize_api_request.rb
@@ -18,8 +18,8 @@ module AuthServices
     def extract_user
       # check if user is present in the db and memoize user object
       @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
-    rescue ActiverRecord::RecordNotFound => e
-      raise ExceptionHandler::InvalidToken "#{Message.invalid_token} #{e.message}"
+    rescue ActiveRecord::RecordNotFound => e
+      raise ExceptionHandler::InvalidToken, Message.invalid_token
     end
 
     def decoded_auth_token


### PR DESCRIPTION
- Ternary check for current user while setting Sentry context
- Pretty message for invalid token related errors
- Avoiding Sentry alerting for **all** errors
- Fixes issue #31 